### PR TITLE
Add tests for header parsing

### DIFF
--- a/tests/models/user.test.ts
+++ b/tests/models/user.test.ts
@@ -1,0 +1,18 @@
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import testEnvOrExit from "../testEnvOrExit.ts";
+import initDB from "../../src/models/initDB.ts";
+import db from "../../src/models/db.ts";
+import resetDatabase from "../../src/models/resetDatabase.ts";
+import { checkPassword, findSingleUser } from "../../src/models/user.ts";
+
+Deno.test("The user model tests", async (t) => {
+  await t.step("Test that `DENO_ENV` is `TEST`", () => testEnvOrExit());
+  await t.step(
+    "`null` should be returned when `findSingleUser(username)` is called on an empty DB",
+    () => {
+      resetDatabase();
+      assertEquals(null, findSingleUser("any_username"));
+    },
+  );
+  await t.step("TODO: more tests after creating users to DB", () => {});
+});

--- a/tests/utils/auth.test.ts
+++ b/tests/utils/auth.test.ts
@@ -27,16 +27,6 @@ Deno.test("Auth header parsing should work", async (t) => {
     // did not crash
     assertEquals(pass, "");
   });
-  await t.step("Should handle a malformed header (missing ':')", () => {
-    const creds = {
-      user: "test username",
-      pass: "test password 1",
-    };
-    const header = btoa(`${creds.user}${creds.pass}`);
-    const [user, pass] = parseBasicAuthHeader(`Basic ${header}`);
-    // did not crash
-    assertEquals(pass, "");
-  });
   await t.step("Should handle a malformed header (UPPERCASE'd base64)", () => {
     const creds = {
       user: "test username",

--- a/tests/utils/auth.test.ts
+++ b/tests/utils/auth.test.ts
@@ -1,0 +1,50 @@
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import { parseBasicAuthHeader } from "../../src/utils/auth.ts";
+
+Deno.test("Auth header parsing should work", async (t) => {
+  await t.step("Should handle an empty header", () => {
+    const [user, pass] = parseBasicAuthHeader("");
+    assertEquals(user, "");
+    assertEquals(pass, "");
+  });
+  await t.step("Should parse a proper header correctly", () => {
+    const creds = {
+      user: "test username",
+      pass: "test:password 1",
+    };
+    const header = btoa(`${creds.user}:${creds.pass}`);
+    const [user, pass] = parseBasicAuthHeader(`Basic ${header}`);
+    assertEquals(user, creds.user);
+    assertEquals(pass, creds.pass);
+  });
+  await t.step("Should handle a malformed header (missing ':')", () => {
+    const creds = {
+      user: "test username",
+      pass: "test password 1",
+    };
+    const header = btoa(`${creds.user}${creds.pass}`);
+    const [user, pass] = parseBasicAuthHeader(`Basic ${header}`);
+    // did not crash
+    assertEquals(pass, "");
+  });
+  await t.step("Should handle a malformed header (missing ':')", () => {
+    const creds = {
+      user: "test username",
+      pass: "test password 1",
+    };
+    const header = btoa(`${creds.user}${creds.pass}`);
+    const [user, pass] = parseBasicAuthHeader(`Basic ${header}`);
+    // did not crash
+    assertEquals(pass, "");
+  });
+  await t.step("Should handle a malformed header (UPPERCASE'd base64)", () => {
+    const creds = {
+      user: "test username",
+      pass: "test password 1",
+    };
+    const header = btoa(`${creds.user}:${creds.pass}`).toUpperCase();
+    const [user, pass] = parseBasicAuthHeader(`Basic ${header}`);
+    // did not crash
+    assertEquals(pass, "");
+  });
+});


### PR DESCRIPTION
It still lacks, at least, testing user creation, password checking and user finding.